### PR TITLE
fixed a bug causing runtime error "the second parameter should be passed by reference" in PHP7

### DIFF
--- a/DocExpander.php
+++ b/DocExpander.php
@@ -66,7 +66,7 @@ class DocExpander
                 (RamlDoc::isValidMethod($key) || RamlDoc::isResource($key))
                 && !empty($value)
             ) {
-                $value = call_user_func(__METHOD__, $ramlDoc, $value, $key);
+                $value = self::applyAllToTree($ramlDoc, $value, $key);
             }
         }
 


### PR DESCRIPTION
Fixed a bug causing runtime error "the second parameter should be passed by reference" in PHP7.
