### PR TITLE
Allow not fully documented methods

### DIFF
--- a/RamlDoc.php
+++ b/RamlDoc.php
@@ -134,9 +134,12 @@ class RamlDoc
 
         foreach (explode('/', substr($path, 1)) as $part) {
             $resource = '/' . $part;
+            $fullResource = '/' . strrchr($path, $part);
 
             if (isset($raml[$resource])) {
                 $raml = $raml[$resource];
+            } else if (isset($raml[$fullResource])) {
+                $raml = $raml[$fullResource];
             } else {
                 foreach (array_keys($raml) as $key) {
                     if (static::isParameter($key)) {

--- a/RamlDoc.php
+++ b/RamlDoc.php
@@ -103,7 +103,7 @@ class RamlDoc
     {
         $raml = $this->getPathDefinition($path);
 
-        return isset($raml[$method]);
+        return array_key_exists($method, $raml);
     }
 
     /**

--- a/RamlDoc.php
+++ b/RamlDoc.php
@@ -134,7 +134,7 @@ class RamlDoc
 
         foreach (explode('/', substr($path, 1)) as $part) {
             $resource = '/' . $part;
-            $fullResource = '/' . strrchr($path, $part);
+            $fullResource = '/' . strstr($path, $part);
 
             if (isset($raml[$resource])) {
                 $raml = $raml[$resource];


### PR DESCRIPTION
In our system we are gradually documenting everything, so not every method is fully documented.
Its valid raml to have

``` yaml
/some-resource:
    put:
    get:
```

This means the method is accepted, but there is no further documentation.
The current implementation does not allow this, since the value of the `put` key will be `null`.

Is this accepted behaviour? if so i'll write some tests for it.
